### PR TITLE
Fix macOS dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -718,7 +718,7 @@
 				</os>
 			</activation>
 			<properties>
-				<geckodriver.suffix>mac</geckodriver.suffix>
+				<geckodriver.suffix>macos</geckodriver.suffix>
 				<geckodriver.url>https://github.com/mozilla/geckodriver/releases/download/${geckodriver.version}/geckodriver-${geckodriver.version}-${geckodriver.suffix}.tar.gz</geckodriver.url>
 				<geckodriver.basepath>${settings.localRepository}${file.separator}geckodriver${file.separator}${os.name}${file.separator}${os.arch}</geckodriver.basepath>
 				<geckodriver.compressed.path>${geckodriver.basepath}${file.separator}geckodriver-${geckodriver.version}-${geckodriver.suffix}.tar.gz</geckodriver.compressed.path>


### PR DESCRIPTION
## Error
When the build process is running on the Mac platform, the URL to get the [geckodriver](https://github.com/mozilla/geckodriver) dependency is wrong and the build process fails with the next error:
```
main:
      [get] Getting: https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz
      [get] To: /Users/ivan/.m2/repository/geckodriver/Mac OS X/x86_64/geckodriver-v0.19.1-mac.tar.gz
      [get] Error opening connection java.io.FileNotFoundException: https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz
      [get] Error opening connection java.io.FileNotFoundException: https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz
      [get] Error opening connection java.io.FileNotFoundException: https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz
      [get] Can't get https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz to /Users/ivan/.m2/repository/geckodriver/Mac OS X/x86_64/geckodriver-v0.19.1-mac.tar.gz
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.838 s
[INFO] Finished at: 2018-02-15T10:17:35+01:00
[INFO] Final Memory: 18M/259M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (download-geckodriver) on project example: An Ant BuildException has occured: Can't get https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz to /Users/ivan/.m2/repository/geckodriver/Mac OS X/x86_64/geckodriver-v0.19.1-mac.tar.gz
[ERROR] around Ant part ...<get skipexisting="true" src="https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz" dest="${settings.localRepository}/geckodriver/Mac OS X/x86_64/geckodriver-v0.19.1-mac.tar.gz"/>... @ 5:225 in /Users/ivan/MEGA/MEGAsync/ESEI/17-18/DAA/DAAExample/target/antrun/build-main.xml
[ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (download-geckodriver) on project example: An Ant BuildException has occured: Can't get https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz to /Users/ivan/.m2/repository/geckodriver/Mac OS X/x86_64/geckodriver-v0.19.1-mac.tar.gz
around Ant part ...<get skipexisting="true" src="https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-mac.tar.gz" dest="${settings.localRepository}/geckodriver/Mac OS X/x86_64/geckodriver-v0.19.1-mac.tar.gz"/>... @ 5:225 in /Users/ivan/MEGA/MEGAsync/ESEI/17-18/DAA/DAAExample/target/antrun/build-main.xml
```
## Solution
Change the `suffix` value on the `pom.xml` for Mac systems to `macos`.
The current value is `mac` but the URL builded with this value is not valid. 